### PR TITLE
removes deprecated option

### DIFF
--- a/src/main/scala/com/intenthq/sbt/ThriftPlugin.scala
+++ b/src/main/scala/com/intenthq/sbt/ThriftPlugin.scala
@@ -67,7 +67,7 @@ object ThriftPlugin extends AutoPlugin {
     thrift := "thrift",
     thriftSourceDir <<= sourceDirectory { _ / "main" / "thrift" },
     thriftJavaEnabled := true,
-    thriftJavaOptions := Seq("hashcode"),
+    thriftJavaOptions := Seq(),
     thriftOutputDir <<= sourceManaged { _ / "main" },
     thriftGenerateJava <<= (thriftJavaEnabled, thriftSourceDir, thriftOutputDir, thrift, thriftJavaOptions, streams).map { (te, tsd, tod, t, to, s) =>
       if (te) {


### PR DESCRIPTION
java:hashcode is no longer an option in thrift 0.10.0