### PR TITLE
Upgrade to latest Scala/SBT and add tests for different Thrift versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,16 @@ language: scala
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install libboost-dev libboost-test-dev libboost-program-options-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev
-  - wget http://www.us.apache.org/dist/thrift/0.10.0/thrift-0.10.0.tar.gz
-  - tar xfz thrift-0.10.0.tar.gz && mv thrift-0.10.0 .thrift-0.10.0
-  - cd .thrift-0.10.0 && ./configure --with-java --without-c_glib --without-cpp --without-csharp --without-python --without-ruby --without-haskell --without-perl --without-php --without-erlang --without-go --without-d --without-nodejs --without-lua && make && sudo make install && cd -
+  - wget http://www.us.apache.org/dist/thrift/0.12.0/thrift-0.12.0.tar.gz
+  - tar xfz thrift-0.12.0.tar.gz && mv thrift-0.12.0 .thrift-0.12.0
+  - cd .thrift-0.12.0 && ./configure --with-java --without-c_glib --without-cpp --without-csharp --without-python --without-ruby --without-haskell --without-perl --without-php --without-erlang --without-go --without-d --without-nodejs --without-lua && make && sudo make install && cd -
 scala:
-   - 2.12.3
+   - 2.12.8
 script:
   - sbt compile
+  - sbt scripted
 cache:
   directories:
-   - ~/.thrift-0.10.0
+   - ~/.thrift-0.12.0
    - ~/.ivy2
    - ~/.sbt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,23 @@
 language: scala
+scala:
+   - 2.12.8
+env:
+  # Test Thrift 0.9.3 for compatability with Spark.
+  - THRIFT_VERSION=0.9.3
+  - THRIFT_VERSION=0.10.0
+  - THRIFT_VERSION=0.11.0
+  - THRIFT_VERSION=0.12.0
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install libboost-dev libboost-test-dev libboost-program-options-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev
-  - wget http://www.us.apache.org/dist/thrift/0.12.0/thrift-0.12.0.tar.gz
-  - tar xfz thrift-0.12.0.tar.gz && mv thrift-0.12.0 .thrift-0.12.0
-  - cd .thrift-0.12.0 && ./configure --with-java --without-c_glib --without-cpp --without-csharp --without-python --without-ruby --without-haskell --without-perl --without-php --without-erlang --without-go --without-d --without-nodejs --without-lua && make && sudo make install && cd -
-scala:
-   - 2.12.8
+  - wget http://www.us.apache.org/dist/thrift/$THRIFT_VERSION/thrift-$THRIFT_VERSION.tar.gz
+  - tar xfz thrift-$THRIFT_VERSION.tar.gz && mv thrift-$THRIFT_VERSION .thrift-$THRIFT_VERSION
+  - cd .thrift-$THRIFT_VERSION && ./configure --with-java --without-c_glib --without-cpp --without-csharp --without-python --without-ruby --without-haskell --without-perl --without-php --without-erlang --without-go --without-d --without-nodejs --without-lua && make && sudo make install && cd -
 script:
   - sbt compile
   - sbt scripted
 cache:
   directories:
-   - ~/.thrift-0.12.0
+   - ~/.thrift-$THRIFT_VERSION
    - ~/.ivy2
    - ~/.sbt

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ These aren't supported as sources by SBT but will be available in a `target/gen-
 
 By default, the plugin will compile to Java only. See the settings section below for details on how to enable other languages.
 
-## Instructions
+## Usage
 
 This is an SBT auto-plugin so all you have to do is add the following to your `project/plugins.sbt`:
 
@@ -21,7 +21,16 @@ This is an SBT auto-plugin so all you have to do is add the following to your `p
 addSbtPlugin("com.intenthq.sbt" % "sbt-thrift-plugin" % "1.1.0")
 ```
 
-> *Note:* SBT `0.13.x` and earlier users should use `1.0.5` which is the last release compatible with these versions of SBT. SBT `1.x` is the supported version of SBT from `1.1.0` onwards.
+> *Note:* SBT `0.13.x` and earlier users should use `1.0.5` which is the last release compatible with these versions of SBT. Only SBT `1.x` is supported from `1.1.0` onwards.
+
+### Installing Thrift
+
+This plugin depends on having the `thrift` binary in your `PATH` — it does not add any speciifc dependency on `libthrift` for you. This means you should:
+
+* Make sure the correct version of `thrift` you need is installed on your system and in your `PATH`.
+* Make sure you add a dependency on the correct version of `libthrift` to the application.
+
+We have automated tests for this plugin running using the latest Thrift version (currently `0.12.0`) and `0.9.x` (used by the Spark ecosystem).
 
 ## Settings
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,35 +1,46 @@
-sbtPlugin := true
-organization := "com.intenthq.sbt"
-name := "sbt-thrift-plugin"
-version := "1.1.0"
-scalaVersion := "2.12.3"
-scalacOptions ++= Seq("-deprecation", "-feature")
+lazy val root = (project in file("."))
+  .enablePlugins(SbtPlugin)
+  .settings(
+    sbtPlugin := true,
+    organization := "com.intenthq.sbt",
+    name := "sbt-thrift-plugin",
+    version := "1.1.1-SNAPSHOT",
+    scalaVersion := "2.12.8",
+    scalacOptions ++= Seq("-deprecation", "-feature"),
 
-publishTo := {
-  val nexus = "https://oss.sonatype.org/"
-  if (isSnapshot.value)
-    Some("snapshots" at nexus + "content/repositories/snapshots")
-  else
-    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
-}
+    // Settings for running SBT scripted tests for this plugin.
+    // See https://www.scala-sbt.org/1.x/docs/Testing-sbt-plugins.html for more
+    // information.
+    scriptedLaunchOpts := { scriptedLaunchOpts.value ++
+      Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
+    },
 
-pomExtra := (
-  <url>https://github.com/intenthq/sbt-thrift-plugin</url>
-  <licenses>
-    <license>
-      <name>The MIT License (MIT)</name>
-      <url>https://github.com/intenthq/sbt-thrift-plugin/blob/master/LICENSE</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
-  <scm>
-    <url>git@github.com:intenthq/sbt-thrift-plugin.git</url>
-    <connection>scm:git:git@github.com:intenthq/sbt-thrift-plugin.git</connection>
-  </scm>
-  <developers>
-    <developer>
-      <id>intenthq</id>
-      <name>Intent HQ</name>
-    </developer>
-  </developers>
-)
+    publishTo := {
+      val nexus = "https://oss.sonatype.org/"
+      if (isSnapshot.value)
+        Some("snapshots" at nexus + "content/repositories/snapshots")
+      else
+        Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+    },
+
+    pomExtra := (
+      <url>https://github.com/intenthq/sbt-thrift-plugin</url>
+      <licenses>
+        <license>
+          <name>The MIT License (MIT)</name>
+          <url>https://github.com/intenthq/sbt-thrift-plugin/blob/master/LICENSE</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+      <scm>
+        <url>git@github.com:intenthq/sbt-thrift-plugin.git</url>
+        <connection>scm:git:git@github.com:intenthq/sbt-thrift-plugin.git</connection>
+      </scm>
+      <developers>
+        <developer>
+          <id>intenthq</id>
+          <name>Intent HQ</name>
+        </developer>
+      </developers>
+    )
+  )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.1
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
+addSbtPlugin("io.crashbox" % "sbt-gpg" % "0.2.0")

--- a/src/sbt-test/sbt-thrift-plugin/compiles-thrift/build.sbt
+++ b/src/sbt-test/sbt-thrift-plugin/compiles-thrift/build.sbt
@@ -1,0 +1,6 @@
+lazy val root = (project in file("."))
+  .settings(
+    version := "0.1",
+    scalaVersion := "2.12.8",
+    libraryDependencies += "org.apache.thrift" % "libthrift" % "0.12.0"
+  )

--- a/src/sbt-test/sbt-thrift-plugin/compiles-thrift/project/plugins.sbt
+++ b/src/sbt-test/sbt-thrift-plugin/compiles-thrift/project/plugins.sbt
@@ -1,0 +1,6 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.intenthq.sbt" % "sbt-thrift-plugin" % x)
+  case _ => addSbtPlugin("com.intenthq.sbt" % "sbt-thrift-plugin" % "1.1.0")
+  // sys.error("""|The system property 'plugin.version' is not defined.
+  //                        |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/sbt-thrift-plugin/compiles-thrift/src/main/scala/com/intenthq/sbt/thrift/Test.scala
+++ b/src/sbt-test/sbt-thrift-plugin/compiles-thrift/src/main/scala/com/intenthq/sbt/thrift/Test.scala
@@ -1,0 +1,9 @@
+package com.intenthq.sbt.thrift
+
+class Test {
+  def main(args: Array[String]): Unit = {
+    val testThrift = new SomeStruct("fieldAValue", SomeEnum.VALUE_B, "fieldCValue")
+
+    println(s"a: ${testThrift.fieldA}, b: ${testThrift.fieldB}, c: ${testThrift.fieldC}")
+  }
+}

--- a/src/sbt-test/sbt-thrift-plugin/compiles-thrift/src/main/thrift/test.thrift
+++ b/src/sbt-test/sbt-thrift-plugin/compiles-thrift/src/main/thrift/test.thrift
@@ -1,0 +1,13 @@
+namespace * com.intenthq.sbt.thrift
+
+enum SomeEnum {
+  VALUE_A,
+  VALUE_B,
+  VALUE_C
+}
+
+struct SomeStruct {
+  1: required string fieldA;
+  2: required SomeEnum fieldB;
+  3: string fieldC;
+}

--- a/src/sbt-test/sbt-thrift-plugin/compiles-thrift/test
+++ b/src/sbt-test/sbt-thrift-plugin/compiles-thrift/test
@@ -1,0 +1,4 @@
+# check if the file gets created
+> compile
+$ exists target/scala-2.12/src_managed/main/com/intenthq/sbt/thrift/SomeEnum.java
+$ exists target/scala-2.12/src_managed/main/com/intenthq/sbt/thrift/SomeStruct.java


### PR DESCRIPTION
This commit adds tests using the SBT scripting framework
(https://www.scala-sbt.org/1.x/docs/Testing-sbt-plugins.html) that
ensure that Thrift sources get compiled correctly with the plugin.
Curently it only tests Java but that's okay for testing at least the
basic framework for now.

I have bumped all of the versions of everything at the same time - Scala
to `0.12.8`, SBT to `1.2.8`.

In addition, we'll now test on CI with Thrift `0.9.3` to `0.12.0` (the commonly
used versions of Thrift we would want to support).

Lastly, I've added documentation on how this plugin uses Thrift and how you
as a user need to install it on your system.